### PR TITLE
Feat/testing message header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 *.egg-info
 Pipfile.lock
 *.back
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 Pipfile.lock
 *.back
 .vscode
+.pytest_cache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "python.pythonPath": "~/.local/share/virtualenvs/messagebus-kafka-python-4EiFMDS9/bin/python",
-  "python.pipenvPath": "pipenv",
-  "python.formatting.provider": "black"
-}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ pip3 install .
 
 This package implements the interface for producer/consumer APIs to push/read messages to/from Kafka via AvroSerializer.
 
+## Testing
+
+```bash
+cd messagebus
+pytest -v
+```
+
 ### Examples
 #### Producers
 

--- a/messagebus/messages/message_header.py
+++ b/messagebus/messages/message_header.py
@@ -1,3 +1,4 @@
+from typing import Mapping
 from uuid import uuid4
 import socket
 from datetime import datetime
@@ -22,7 +23,7 @@ class MessageHeader():
         self.message_bus_version = f"python:kafka_message_bus:v{version}"
         self.timestamp = str(int(datetime.now().timestamp() * 1000))
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> Mapping[str, str]:
         return {
             'value_subject': self.value_subject,
             'message_id': self.message_id,

--- a/messagebus/test/messageheader_test.py
+++ b/messagebus/test/messageheader_test.py
@@ -16,7 +16,7 @@ class MessageBusHeaderTest(unittest.TestCase):
 		# conversation_id
 		self.assertIsNotNone(message_header_dict.get('conversation_id'), message_header_dict.get('message_id'))
 		# origin_service
-		self.assertEqual(message_header_dict.get('origin_service'), 'unknown_service_name')
+		self.assertEqual(message_header_dict.get('origin_service'), 'unknown-service-name')
 		# origin_hostname
 		self.assertIsNotNone(message_header_dict.get('origin_hostname'))
 		self.assertNotEqual(message_header_dict.get('origin_hostname'), '')

--- a/messagebus/test/messageheader_test.py
+++ b/messagebus/test/messageheader_test.py
@@ -1,0 +1,29 @@
+import unittest
+from messagebus.messages.message_header import MessageHeader
+
+class MessageBusHeaderTest(unittest.TestCase):
+
+	def test_new_empty_message_header_to_dict(self):
+		message_header = MessageHeader()
+		message_header_dict = message_header.to_dict()
+		# value_subject
+		self.assertEqual(message_header_dict.get('value_subject'), 'unknown_value_subject')
+		# message_id
+		self.assertNotEqual(message_header_dict.get('message_id'), '')
+		self.assertIsNotNone(message_header_dict.get('message_id'))
+		# correlation_id
+		self.assertIsNotNone(message_header_dict.get('correlation_id'), message_header_dict.get('message_id'))
+		# conversation_id
+		self.assertIsNotNone(message_header_dict.get('conversation_id'), message_header_dict.get('message_id'))
+		# origin_service
+		self.assertEqual(message_header_dict.get('origin_service'), 'unknown_service_name')
+		# origin_hostname
+		self.assertIsNotNone(message_header_dict.get('origin_hostname'))
+		self.assertNotEqual(message_header_dict.get('origin_hostname'), '')
+		# message_bus_version
+		self.assertIsNotNone(message_header_dict.get('message_bus_version'))
+		self.assertNotEqual(message_header_dict.get('message_bus_version'), '')
+		# timestamp
+		self.assertIsNotNone(message_header_dict.get('timestamp'))
+		self.assertNotEqual(message_header_dict.get('timestamp'), '')
+


### PR DESCRIPTION
@sulthonzh n @nurcahyopujo in this PR I move message_header's test to the more appropriate place.
Also, I use `Mapping[str, str]` instead of `dict`. This is better since the result of `MessageHeader.to_dict` is a dictionary with the `string` key and `string` value.